### PR TITLE
Bump ws from 8.17.0 to 8.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
     "pnpm": "8.15.8"
   },
   "packageManager": "pnpm@8.15.8",
-  "private": true
+  "private": true,
+  "pnpm": {
+    "overrides": {
+      "ws@>=8.0.0 <8.17.1": ">=8.17.1"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ws@>=8.0.0 <8.17.1: '>=8.17.1'
+
 dependencies:
   feed:
     specifier: ^4.2.2
@@ -316,7 +319,7 @@ packages:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.0.0
-      ws: 8.17.0
+      ws: 8.18.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -564,8 +567,8 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /ws@8.17.0:
-    resolution: {integrity: sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==}
+  /ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
Bump ws from 8.17.0 to 8.18.0

```
$ pnpm audit
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ high                │ ws affected by a DoS when handling a request with many │
│                     │ HTTP headers                                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ ws                                                     │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ >=8.0.0 <8.17.1                                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=8.17.1                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ . > jsdom@24.1.0 > ws@8.17.0                           │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-3h5v-q93c-6h6q      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 high

$ pnpm audit --fix
1 overrides were added to package.json to fix vulnerabilities.
Run "pnpm install" to apply the fixes.

The added overrides:
{
  "ws@>=8.0.0 <8.17.1": ">=8.17.1"
}
```

## Ref

- https://github.com/ohakutsu/zutomayo-rss/pull/252